### PR TITLE
fix bug in __al_main_loop

### DIFF
--- a/alipy/experiment/al_experiment.py
+++ b/alipy/experiment/al_experiment.py
@@ -380,7 +380,7 @@ class AlExperiment:
                 querfunction = QueryInstanceQUIRE(self._X, self._y, train_id, **self._query_function_kwargs)
 
         # performance calc
-        perf_result = self._performance_metric(pred, self._y[test_id])
+        perf_result = self._performance_metric(self._y[test_id], pred)
 
         # stopping-criterion 
         stopping_criterion = copy.deepcopy(self._stopping_criterion)
@@ -411,7 +411,7 @@ class AlExperiment:
             pred = self._model.predict(self._X[test_id, :])
 
             # performance calc
-            perf_result = self._performance_metric(pred, self._y[test_id])
+            perf_result = self._performance_metric(self._y[test_id], pred)
 
             # save intermediate results
             st = State(select_index=select_ind, performance=perf_result)


### PR DESCRIPTION
This PR proposes to fix a bug in the `__al_main_loop`. Specifically, in `__al_main_loop` of `alipy.experiment.al_experiment`, ALiPy calculates the model performance after each query like below

```python
perf_result = self._performance_metric(pred, self._y[test_id])
```

But `ALiPy` uses the sklearn-style evaluation functions, where the true labels come first and the predicted labels follow. Therefore, the original implementation will reverse the true labels and the predicted labels when evaluation, which may be OK for metrics like accuracy. But for other metrics, it may be wrong. What's worse, it will miss some checks on the true labels, e.g., they should contain all class labels. 